### PR TITLE
Use skypack cdn

### DIFF
--- a/src/packages.js
+++ b/src/packages.js
@@ -17,10 +17,13 @@ export {
 } from 'https://unpkg.com/haunted@4.7.0/haunted.js';
 //} from 'https://cdn.skypack.dev/haunted@^4.7.0';
 
-export { css, cx } from 'https://cdn.skypack.dev/emotion@10';
+//export { css, cx } from 'https://cdn.skypack.dev/emotion@10';
+export { css, cx } from 'https://cdn.skypack.dev/pin/emotion@v10.0.27-tWRcn3IFvfEGeRY3DmsO/min/emotion.js';
 
-export { scaleLinear } from 'https://cdn.skypack.dev/d3-scale@^3.2.1';
-export { interpolateZoom } from "https://cdn.skypack.dev/d3-interpolate@^1.4.0";
+//export { scaleLinear } from 'https://cdn.skypack.dev/d3-scale@^3.2.1';
+export { scaleLinear } from 'https://cdn.skypack.dev/pin/d3-scale@v3.2.1-hRLU1HRH67TnClzRzsnV/min/d3-scale.js';
+//export { interpolateZoom } from "https://cdn.skypack.dev/d3-interpolate@^1.4.0";
+export { interpolateZoom } from "https://cdn.skypack.dev/pin/d3-interpolate@v1.4.0-9kCOKUBNhbsyJcbcKe7n/min/d3-interpolate.js";
 
 //export { Spring } from 'https://cdn.pika.dev/-/wobble@v1.5.1-PY119JqBR3I6IVYF801i/dist=es2017/wobble.js';
 export { Spring } from './wobble.es.js';


### PR DESCRIPTION
Pika is being renamed to Skypack. https://docs.skypack.dev/

Uses a few pinned, minified urls.