### PR TITLE
Prevent duplicate deck nodes breaking render

### DIFF
--- a/src/fetch-deck.js
+++ b/src/fetch-deck.js
@@ -9,5 +9,18 @@ export const fetchDeck = async (slug = defaultSlug) => {
     }
   });
   const json = await response.json();
-  return json;
+  console.log('original json', json);
+  // dedupe nodes. one deck per slug.
+  const deduped = {
+    ...json,
+    nodes: Object.values(json.nodes.reduce((bySlug, node) => {
+      const slug = node.slug;
+      if (!bySlug[slug]) {
+        bySlug[slug] = node;
+      }
+      return bySlug;
+    }, {}))
+  };
+  console.log('deduped', deduped);
+  return deduped;
 };

--- a/src/fetch-deck.js
+++ b/src/fetch-deck.js
@@ -9,7 +9,6 @@ export const fetchDeck = async (slug = defaultSlug) => {
     }
   });
   const json = await response.json();
-  console.log('original json', json);
   // dedupe nodes. one deck per slug.
   const deduped = {
     ...json,
@@ -21,6 +20,5 @@ export const fetchDeck = async (slug = defaultSlug) => {
       return bySlug;
     }, {}))
   };
-  console.log('deduped', deduped);
   return deduped;
 };


### PR DESCRIPTION
This pull request fixes the following TypeError:

![Screen Shot 2020-08-15 at 9 36 33 AM](https://user-images.githubusercontent.com/9389/90316980-10d7be80-dedb-11ea-9026-a536b4098845.png)

You can reproduce it by navigating to a deck:

![before-broken](https://user-images.githubusercontent.com/9389/90316989-192ff980-dedb-11ea-9c7d-125287cb36c6.gif)


The `repeat` lit-html directive (https://lit-html.polymer-project.org/guide/template-reference#repeat) is used to optimize the rendering of the decks and expected unique keys.  I'm using the deck slug as the key.

    When the keyFn is provided, key-to-DOM association is maintained
    between updates by moving DOM when required, and is generally the
    most efficient way to use repeat since it performs minimum
    unnecessary work for insertions and removals.

The space deck endpoint (`https://tappedout.net/api/decks/15-02-20-mono-blue/space/`) is now mostly comprised of duplicate deck nodes. Only 169 of 495 nodes are unique, and the dupe nodes are throwing the `repeat` directive off.

![Screen Shot 2020-08-15 at 9 46 30 AM](https://user-images.githubusercontent.com/9389/90317161-4b8e2680-dedc-11ea-8537-a718d8c3a039.png)


The fix is achieved by modifying the `fetchDeck` function to return a json object that has the duplicate decks filtered out. If the response can be fixed to not include the extra nodes, then this filter call can be removed and the original json can be used.

Here is a demo of things working again: ![after-fixed](https://user-images.githubusercontent.com/9389/90317111-fce08c80-dedb-11ea-8c6d-2a92cdf146f5.gif)
