### PR TITLE
Add zoom levels

### DIFF
--- a/index.html
+++ b/index.html
@@ -1,5 +1,6 @@
 <html>
   <head>
+    <meta name="viewport" content="width=device-width, initial-scale=1">
     <link href="./space.css" rel="stylesheet" type="text/css" media="screen" />
     <script>
         window.django = {deckSlug: "16-05-20-black-zombie"}

--- a/space.css
+++ b/space.css
@@ -5,6 +5,8 @@
   box-sizing: border-box;
 }
 html, body, #root {
+  /*background: radial-gradient(ellipse at top, #999, #111), radial-gradient(ellipse at bottom, #111, #999);*/
+  /*background: linear-gradient(#302550, #1f0c3e);*/
   background-color: var(--stage-background-color);
   margin: 0;
   padding: 0;

--- a/src/app.js
+++ b/src/app.js
@@ -45,14 +45,14 @@ export const App = virtual(() => {
   const slug = state.lastLoadingSlug;
   const json = state.lastLoadedSlug && state.bySlug[state.lastLoadedSlug].json;
   const { width, height } = useViewport();
-  const { value: zoomed, on: zoom, reset: unzoom } = useComposeActiveState(
-    "ZOOM",
+  const { value: focused, on: focus, reset: unfocus } = useComposeActiveState(
+    "FOCUS",
     slug
   );
 
   useEffect(() => {
-    zoom(slug);
-  }, [zoom, slug]);
+    focus(slug);
+  }, [focus, slug]);
 
   const decks = json && json.nodes || EMPTY_ARRAY;
 
@@ -83,7 +83,7 @@ export const App = virtual(() => {
         width,
         height,
         bySlug,
-        zoomed,
+        focused,
         loading: state.loading,
       })}
       ${state.lastLoadedSlug
@@ -91,9 +91,9 @@ export const App = virtual(() => {
             width,
             height,
             data: dataWithClusters,
-            zoomed,
-            zoom,
-            unzoom,
+            focused,
+            focus,
+            unfocus,
             bySlug,
           })
         : ""}

--- a/src/app.js
+++ b/src/app.js
@@ -14,6 +14,7 @@ import { Hud } from "./hud.js";
 import { useComposeActiveState } from "./use-compose-active-state.js";
 import { useLocationHash } from "./use-location-hash.js";
 import { useSpace } from "./use-space.js";
+import { useZoomLevels } from "./use-zoom-levels.js";
 
 const styles = css`
   color: white;
@@ -49,6 +50,7 @@ export const App = virtual(() => {
     "FOCUS",
     slug
   );
+  const zoomLevel = useZoomLevels();
 
   useEffect(() => {
     focus(slug);
@@ -85,6 +87,7 @@ export const App = virtual(() => {
         bySlug,
         focused,
         loading: state.loading,
+        zoomLevel
       })}
       ${state.lastLoadedSlug
         ? Svg({
@@ -95,6 +98,7 @@ export const App = virtual(() => {
             focus,
             unfocus,
             bySlug,
+            zoomLevel
           })
         : ""}
     </div>

--- a/src/deck.js
+++ b/src/deck.js
@@ -14,7 +14,7 @@ const votesSize = (votes) => {
   return 'small'
 }
 
-export const Deck = ({ deck, cx, cy, highlighted, zoomed, r, circumference }) => {
+export const Deck = ({ deck, cx, cy, highlighted, focused, r, circumference }) => {
   const cluster = parseCluster(deck.cluster);
   const gradient = `grad_${deck.mana_colors.join('')}`;
   return svg`
@@ -26,7 +26,7 @@ export const Deck = ({ deck, cx, cy, highlighted, zoomed, r, circumference }) =>
         data-slug="${deck.slug}"
         id="deck-${deck.slug}"
         data-highlighted=${highlighted}
-        data-zoomed=${zoomed}
+        data-focused=${focused}
         data-votes-size=${votesSize(deck.votes)}
         fill=${`url(#${gradient})`}
       />

--- a/src/deck.js
+++ b/src/deck.js
@@ -28,7 +28,7 @@ export const Deck = ({ deck, cx, cy, highlighted, focused, r, circumference }) =
         data-highlighted=${highlighted}
         data-focused=${focused}
         data-votes-size=${votesSize(deck.votes)}
-        fill=${`url(#${gradient})`}
+        fill=${`url(${window.location.pathname}#${gradient})`}
       />
     </g>
   `;

--- a/src/gradients.js
+++ b/src/gradients.js
@@ -12,7 +12,32 @@ const calculateOffset = (i, total) => {
   return offsets[total - 1][i];
 };
 
+const hsls = {
+  B: [0, 0, 0],
+  R: [0, 100, 50],
+  G: [114, 100, 50],
+  U: [230, 100, 50],
+  W: [0, 0, 100],
+};
+
+const MonoColorLinearGradient = (stops) => {
+  const [stop] = stops;
+  const [h, s, l] = hsls[stop];
+  const lightened = Math.min(100, l + 20);
+  const darkened = Math.max(0, l - 20);
+  return svg`
+    <linearGradient id="grad_${stops}" x1="0" x2="0" y1="1" y2="0">
+      <stop stop-color="hsl(${h}, ${s}%, ${darkened}%)" offset="0%" />
+      <stop class="stop-${stop}" offset="50%" />
+      <stop stop-color="hsl(${h}, ${s}%, ${lightened}%)" offset="100%" />
+    </linearGradient>
+  `;
+};
+
 const LinearGradient = (stops) => {
+  if (stops.length === 1) {
+    return MonoColorLinearGradient(stops);
+  }
   return svg`
     <linearGradient id="grad_${stops}" x1="0" x2="0" y1="1" y2="0">
       ${stops.split("").map((stop, i) => {
@@ -23,11 +48,56 @@ const LinearGradient = (stops) => {
   `;
 };
 
-export const LinearGradients = (reorderedDecks) => {
+const sortStops = (stops) => {
+  stops = stops.split("");
+  if (stops.includes("B")) {
+    const index = stops.indexOf("B");
+    stops.splice(index, 1);
+    stops = [...stops, "B"];
+  }
+  if (stops.includes("W")) {
+    const index = stops.indexOf("W");
+    stops.splice(index, 1);
+    stops = ["W", ...stops];
+  }
+  let sorted = stops.join("");
+  return sorted;
+};
+
+const BlackRadialGradient = () => {
+  return svg`
+    <radialGradient id="grad_B" fx="80%" fy="20%" r="70%">
+      <stop stop-color="gray" offset="10%" />
+      <stop class="stop-B" offset="50%" />
+      <stop stop-color="#222" offset="80%" />
+      <stop class="stop-B" offset="100%" />
+    </radialGradient>
+  `;
+};
+
+const RadialGradient = (stops) => {
+  if (stops === "B") {
+    return BlackRadialGradient();
+  }
+  return svg`
+    <radialGradient id="grad_${stops}" fx="80%" fy="20%" r="70%">
+      ${sortStops(stops)
+        .split("")
+        .map((stop, i) => {
+          const offset = calculateOffset(i, stops.length);
+          return svg`<stop class="stop-${stop}" offset="${offset}%" />`;
+        })}
+    </radialGradient>
+  `;
+};
+
+export const Gradients = (reorderedDecks, type) => {
   const gradients = useMemo(() => {
     return new Set(reorderedDecks.map((deck) => deck.mana_colors.join("")));
   }, [reorderedDecks]);
-  return svg`${[...gradients].map((stops) => {
-    return LinearGradient(stops);
-  })}`;
+  return svg`
+    ${[...gradients].map((stops) => {
+      return LinearGradient(stops);
+    })}
+  `;
 };

--- a/src/hud.js
+++ b/src/hud.js
@@ -1,8 +1,8 @@
 import { html, css } from "./packages.js";
 import { parseCluster } from "./parse-cluster.js";
 
-export const Hud = ({ width, height, bySlug, zoomed, loading }) => {
-  const deck = bySlug[zoomed];
+export const Hud = ({ width, height, bySlug, focused, loading }) => {
+  const deck = bySlug[focused];
   return html`
     <div
       class=${css`

--- a/src/hud.js
+++ b/src/hud.js
@@ -1,7 +1,7 @@
 import { html, css } from "./packages.js";
 import { parseCluster } from "./parse-cluster.js";
 
-export const Hud = ({ width, height, bySlug, focused, loading }) => {
+export const Hud = ({ width, height, bySlug, focused, loading, zoomLevel }) => {
   const deck = bySlug[focused];
   return html`
     <div
@@ -17,6 +17,7 @@ export const Hud = ({ width, height, bySlug, focused, loading }) => {
       ${deck ? html`
       Name: <a target="_blank" href="${deck.slug}">${deck.name}</a>
       <br />
+      ${location.host.includes('localhost') ? html`<br />zoom level: ${zoomLevel}<br />` : '' }
       <img src="${deck.mana_chart_thumbnail}" />
       ` : '' }
       ${loading ? html`<br /><br />Loading...<br />` : '' }

--- a/src/packages.js
+++ b/src/packages.js
@@ -1,7 +1,8 @@
-export { svg, render } from 'https://unpkg.com/lit-html@1.2.1/lit-html.js';
-//export { svg, render } from 'https://cdn.skypack.dev/lit-html@^1.2.1';
-export { repeat } from 'https://unpkg.com/lit-html@1.2.1/directives/repeat.js';
-//export { repeat } from 'https://cdn.skypack.dev/lit-html@^1.2.1/directives/repeat.js';
+//export { svg, render } from 'https://unpkg.com/lit-html/lit-html.js';
+export { svg, render } from 'https://unpkg.com/lit-html@1.3.0/lit-html.js';
+//export { svg, render } from 'https://cdn.skypack.dev/lit-html@^1.3.0';
+export { repeat } from 'https://unpkg.com/lit-html@1.3.0/directives/repeat.js';
+//export { repeat } from 'https://cdn.skypack.dev/lit-html@^1.3.0/directives/repeat.js';
 export {
   html,
   component,

--- a/src/svg.js
+++ b/src/svg.js
@@ -100,6 +100,7 @@ export const Svg = ({ bySlug, data, width, height, focused, focus, unfocus, zoom
   );
   const click = useCallback(
     e => {
+      e.preventDefault();
       const slug = e.target.dataset.slug;
       const params = window.location.hash.split('?')[1];
       if (slug) window.location.hash = slug + (params ? '?' + params : '');
@@ -225,7 +226,7 @@ export const Svg = ({ bySlug, data, width, height, focused, focus, unfocus, zoom
       @click=${click}
     >
       <defs>${Gradients(decks)}</defs>
-      <g id="view-scale" transform="${transformScale}" transform-origin="${'center'}" class="view">
+      <g id="view-scale" transform="${transformScale}" transform-origin="center" class="view">
       <g id="view" transform="${transform}" class="view">
         ${repeat(
           reorderedDecks,

--- a/src/svg.js
+++ b/src/svg.js
@@ -17,7 +17,7 @@ import { useSprings } from "./use-springs.js";
 import { useComposeActiveState } from "./use-compose-active-state.js";
 import { Gradients } from "./gradients.js";
 
-const useZoomSpring2 = (ik) => {
+const useZoomSpring = (ik) => {
   const k = useSpring2({ fromValue: ik, toValue: ik, stiffness: 150, damping: 50, mass: 3 });
   const update = useCallback((_k) => {
     k.updateConfig({ toValue: _k });
@@ -135,7 +135,7 @@ export const Svg = ({ bySlug, data, width, height, focused, focus, unfocus, zoom
   );
   const zScale = scaleLinear().domain([1, 5]).range([0.2, 1]);
   const nextZoom = zScale(zoomLevel)
-  const { k, update: updateZoomSpring } = useZoomSpring2(nextZoom);
+  const { k, update: updateZoomSpring } = useZoomSpring(nextZoom);
 
   useEffect(() => {
     updatePanSpring(...nextPan);
@@ -224,7 +224,7 @@ export const Svg = ({ bySlug, data, width, height, focused, focus, unfocus, zoom
       @mouseout=${mouseout}
       @click=${click}
     >
-      <defs>${Gradients(reorderedDecks)}</defs>
+      <defs>${Gradients(decks)}</defs>
       <g id="view-scale" transform="${transformScale}" transform-origin="${'center'}" class="view">
       <g id="view" transform="${transform}" class="view">
         ${repeat(

--- a/src/svg.js
+++ b/src/svg.js
@@ -18,20 +18,22 @@ import { useComposeActiveState } from "./use-compose-active-state.js";
 import { LinearGradients } from "./gradients.js";
 
 const useZoomSpring2 = (ik) => {
-  const k = useSpring2({ fromValue: ik, toValue: ik, stiffness: 250, damping: 20, mass: 2 });
+  const k = useSpring2({ fromValue: ik, toValue: ik, stiffness: 150, damping: 50, mass: 3 });
   const update = useCallback((_k) => {
     k.updateConfig({ toValue: _k });
     k.start();
   }, [k]);
-  return { update, k: k.currentValue };
+  const springs = useMemo(() => [k], [k]);
+  const [currentKValue] = useSprings(springs);
+  return { update, k: currentKValue };
 };
 
 const usePanSpring = (ix, iy) => {
-  const x = useSpring2({ fromValue: ix, toValue: ix, stiffness: 500, damping: 30, mass: 3 });
-  const y = useSpring2({ fromValue: iy, toValue: iy, stiffness: 500, damping: 30, mass: 3 });
+  const x = useSpring2({ fromValue: ix, toValue: ix, stiffness: 100, damping: 50, mass: 10 });
+  const y = useSpring2({ fromValue: iy, toValue: iy, stiffness: 100, damping: 50, mass: 10 });
   const update = useCallback((_x, _y, _k) => {
-    x.updateConfig({ toValue: _x, stiffness: 500, damping: 30 });
-    y.updateConfig({ toValue: _y, stiffness: 500, damping: 30 });
+    x.updateConfig({ toValue: _x });
+    y.updateConfig({ toValue: _y });
     x.start();
     y.start();
   }, [x, y]);

--- a/src/svg.js
+++ b/src/svg.js
@@ -15,7 +15,7 @@ import { Deck } from "./deck.js";
 import { useSpring, useSpring2 } from "./use-spring.js";
 import { useSprings } from "./use-springs.js";
 import { useComposeActiveState } from "./use-compose-active-state.js";
-import { LinearGradients } from "./gradients.js";
+import { Gradients } from "./gradients.js";
 
 const useZoomSpring2 = (ik) => {
   const k = useSpring2({ fromValue: ik, toValue: ik, stiffness: 150, damping: 50, mass: 3 });
@@ -224,7 +224,7 @@ export const Svg = ({ bySlug, data, width, height, focused, focus, unfocus, zoom
       @mouseout=${mouseout}
       @click=${click}
     >
-      <defs>${LinearGradients(reorderedDecks)}</defs>
+      <defs>${Gradients(reorderedDecks)}</defs>
       <g id="view-scale" transform="${transformScale}" transform-origin="${'center'}" class="view">
       <g id="view" transform="${transform}" class="view">
         ${repeat(

--- a/src/svg.js
+++ b/src/svg.js
@@ -35,7 +35,7 @@ const useZoomSpring = (ix, iy, ik) => {
 };
 
 
-export const Svg = ({ bySlug, data, width, height, zoomed, zoom, unzoom }) => {
+export const Svg = ({ bySlug, data, width, height, focused, focus, unfocus }) => {
   const viewBox = `0 0 ${width} ${height}`;
   const decks = data.nodes;
   const {
@@ -59,15 +59,15 @@ export const Svg = ({ bySlug, data, width, height, zoomed, zoom, unzoom }) => {
     return { xValues, yValues, xScale, yScale };
   }, [decks, width, height]);
   const reorderedDecks = useMemo(() => {
-    if (highlighted || zoomed) {
+    if (highlighted || focused) {
       const hDeck = bySlug[highlighted];
-      const zDeck = bySlug[zoomed];
+      const zDeck = bySlug[focused];
       const reordered = decks.slice();
       if (highlighted) {
         reordered.splice(reordered.indexOf(hDeck), 1);
         reordered.push(hDeck);
       }
-      if (zoomed) {
+      if (focused) {
         reordered.splice(reordered.indexOf(zDeck), 1);
         reordered.push(zDeck);
       }
@@ -75,7 +75,7 @@ export const Svg = ({ bySlug, data, width, height, zoomed, zoom, unzoom }) => {
     } else {
       return decks;
     }
-  }, [decks, highlighted, zoomed, bySlug]);
+  }, [decks, highlighted, focused, bySlug]);
   const mouseover = useCallback(
     e => {
       const slug = e.target.dataset.slug;
@@ -94,30 +94,30 @@ export const Svg = ({ bySlug, data, width, height, zoomed, zoom, unzoom }) => {
     e => {
       const slug = e.target.dataset.slug;
       if (slug) window.location.hash = slug;
-      //if (slug) zoom(slug);
+      //if (slug) focus(slug);
     },
-    [zoom, unzoom]
+    [focus, unfocus]
   );
-  // r = 1 is equal to 1px while completely zoomed out, when the coordinate space is entirely in view.
+  // r = 1 is equal to 1px while completely focused out, when the coordinate space is entirely in view.
   const r = 0.1; // radius
   const diameter = r * 2;
 
-  const nextZoom = ((r, zoomedDeck) => {
+  const nextZoom = ((focusedDeck) => {
     // returning [0, 0, 1] will fit the entire coordinate space into the svg area, viewing everything. Decks will look tiny.
-    if (!zoomedDeck) return [0, 0, 1];
+    if (!focusedDeck) return [0, 0, 1];
     // the larger the factor, the more zoomed out.
     // size = 1 * diameter means that one deck circle will fit the viewport at the smallest dimension.
     // size = 10 * diameter means that ten deck circles can fit the viewport at the smallest dimension.
     const size = diameter * 10
-    const centerX = xScale(zoomedDeck.x);
-    const centerY = yScale(zoomedDeck.y);
+    const centerX = xScale(focusedDeck.x);
+    const centerY = yScale(focusedDeck.y);
     const k = Math.min(width, height) / size; // scale
     const translate = [
       width / 2 - centerX * k,
       height / 2 - centerY * k
     ];
     return [...translate, k];
-  })(r, zoomed && bySlug[zoomed]);
+  })(focused && bySlug[focused]);
 
   const { syncedValues, update: updateZoomSpring } = useZoomSpring(
     ...nextZoom
@@ -161,7 +161,7 @@ export const Svg = ({ bySlug, data, width, height, zoomed, zoom, unzoom }) => {
             stroke-width: calc(var(--r) / 7);
           }
 
-          &[data-zoomed="true"], &:active {
+          &[data-focused="true"], &:active {
             stroke: white;
             stroke-width: calc(var(--r) / 5);
           }
@@ -215,7 +215,7 @@ export const Svg = ({ bySlug, data, width, height, zoomed, zoom, unzoom }) => {
               cy: yScale(deck.y),
               r,
               highlighted: deck.slug === highlighted,
-              zoomed: deck.slug === zoomed,
+              focused: deck.slug === focused,
               circumference
             });
           }

--- a/src/svg.js
+++ b/src/svg.js
@@ -115,8 +115,7 @@ export const Svg = ({ bySlug, data, width, height, focused, focus, unfocus, zoom
     // the larger the factor, the more zoomed out.
     // size = 1 * diameter means that one deck circle will fit the viewport at the smallest dimension.
     // size = 10 * diameter means that ten deck circles can fit the viewport at the smallest dimension.
-    const zScale = scaleLinear().domain([1, 5]).range([15, 8]);
-    const size = diameter * zScale(zoomLevel)
+    const size = 1// diameter * zScale(zoomLevel)
 
     const centerX = xScale(focusedDeck.x);
     const centerY = yScale(focusedDeck.y);
@@ -132,7 +131,8 @@ export const Svg = ({ bySlug, data, width, height, focused, focus, unfocus, zoom
   const { syncedValues, update: updatePanSpring } = usePanSpring(
     ...nextPan
   );
-  const nextZoom = nextPan[2];
+  const zScale = scaleLinear().domain([1, 5]).range([0.2, 1]);
+  const nextZoom = zScale(zoomLevel)
   const { k, update: updateZoomSpring } = useZoomSpring2(nextZoom);
 
   useEffect(() => {
@@ -143,8 +143,10 @@ export const Svg = ({ bySlug, data, width, height, focused, focus, unfocus, zoom
     updateZoomSpring(nextZoom);
   }, [nextZoom]);
 
+  const panK = nextPan[2];
   const [translateX, translateY] = syncedValues;
-  const transform = `translate(${translateX}, ${translateY}) scale(${k})`;
+  const transform = `translate(${translateX}, ${translateY}) scale(${panK})`;
+  const transformScale = `scale(${k})`;
   const circumference = 2 * Math.PI * r;
   return html`
     <svg
@@ -221,6 +223,7 @@ export const Svg = ({ bySlug, data, width, height, focused, focus, unfocus, zoom
       @click=${click}
     >
       <defs>${LinearGradients(reorderedDecks)}</defs>
+      <g id="view-scale" transform="${transformScale}" transform-origin="${'center'}" class="view">
       <g id="view" transform="${transform}" class="view">
         ${repeat(
           reorderedDecks,
@@ -237,6 +240,7 @@ export const Svg = ({ bySlug, data, width, height, focused, focus, unfocus, zoom
             });
           }
         )}
+      </g>
       </g>
     </svg>
   `;

--- a/src/use-location-hash.js
+++ b/src/use-location-hash.js
@@ -1,4 +1,4 @@
-import { useEffect, useState, useCallback } from './packages.js';
+import { useEffect, useState, useCallback, useMemo } from './packages.js';
 
 export const useLocationHash = () => {
   const [hash, setHash] = useState(window.location.hash);
@@ -12,4 +12,24 @@ export const useLocationHash = () => {
     };
   }, [onChange]);
   return hash;
+};
+
+export const useLocationHashQueryParams = () => {
+  const hash = useLocationHash();
+  const [head, hashParamString] = hash.split('?');
+  return useMemo(() => {
+    const queryParams = new URLSearchParams(hashParamString);
+    const updateQueryParams = (newParams) => {
+      const newQueryParams = new URLSearchParams(queryParams);
+      Object.entries(newParams).forEach(([key, value]) => {
+        if (value === null) {
+          newQueryParams.delete(key);
+        } else {
+          newQueryParams.set(key, value);
+        }
+      });
+      location.hash = head + '?' + newQueryParams;
+    };
+    return { queryParams, updateQueryParams };
+  }, [hashParamString]);
 };

--- a/src/use-location-hash.js
+++ b/src/use-location-hash.js
@@ -28,7 +28,6 @@ export const useLocationHashQueryParams = () => {
           newQueryParams.set(key, value);
         }
       });
-      console.log('head', head);
       location.hash = head + '?' + newQueryParams;
     };
     return { queryParams, updateQueryParams };

--- a/src/use-location-hash.js
+++ b/src/use-location-hash.js
@@ -28,8 +28,9 @@ export const useLocationHashQueryParams = () => {
           newQueryParams.set(key, value);
         }
       });
+      console.log('head', head);
       location.hash = head + '?' + newQueryParams;
     };
     return { queryParams, updateQueryParams };
-  }, [hashParamString]);
+  }, [hashParamString, head]);
 };

--- a/src/use-space.js
+++ b/src/use-space.js
@@ -58,7 +58,7 @@ export const useSpace = () => {
   useEffect(async () => {
     if (!hash) window.location.hash = defaultSlug;
     if (hash) {
-      const slug = hash.replace("#", "");
+      const slug = hash.replace("#", "").split("?")[0];
       dispatch({ type: "load", slug });
       const json = await fetchDeck(slug);
       dispatch({ type: "loaded", json, slug });

--- a/src/use-zoom-levels.js
+++ b/src/use-zoom-levels.js
@@ -1,0 +1,53 @@
+import { useEffect } from "./packages.js";
+import { useLocationHashQueryParams } from "./use-location-hash.js";
+import { defaultSlug, fetchDeck } from "./fetch-deck.js";
+
+// zoom: [0, 1, 2, 3, 4, 5]
+
+const MAX = 5;
+const MIN = 1;
+const DEFAULT_ZOOM_LEVEL = 5;
+const initialState = 0;
+
+
+const clamp = (value, min, max) => {
+  const lowerLimitApplied = Math.max(value, min);
+  const upperLimitApplied = Math.min(lowerLimitApplied, max);
+  return upperLimitApplied;
+};
+
+const getZoomLevel = queryParams => {
+  const zoomLevelQueryParam = queryParams.get('zoom');
+  if (zoomLevelQueryParam) {
+    const parsed = Number(zoomLevelQueryParam);
+    return clamp(parsed, MIN, MAX);
+  }
+  return DEFAULT_ZOOM_LEVEL;
+};
+
+export const useZoomLevels = () => {
+  const { queryParams, updateQueryParams } = useLocationHashQueryParams();
+  //const [state, dispatch] = useReducer(reducer, initialState);
+  const zoomLevel = getZoomLevel(queryParams);
+
+  const handleDelta = (delta) => {
+    const nextZoom = clamp(zoomLevel + delta, MIN, MAX);
+    if (getZoomLevel(queryParams) !== nextZoom) {
+      updateQueryParams({ zoom: nextZoom });
+    }
+  };
+
+  useEffect(() => {
+    const handleWheel = e => {
+      const delta = Math.sign(e.deltaY);
+      // console.log(delta);// delta is either -1 or 1
+      handleDelta(delta);
+    };
+    window.addEventListener("wheel", handleWheel);
+    return () => {
+      window.removeEventListener("wheel", handleWheel);
+    };
+
+  }, [handleDelta]);
+  return zoomLevel;
+};


### PR DESCRIPTION
This adds 5 zoom levels bound to the mouse wheel. The zoom level state is set in the location.hash. The zoom scale factor is handled in a separate spring applied to a new wrapping `<g>` with it's own transform.


![zippity-zoom](https://user-images.githubusercontent.com/9389/91000714-a976da00-e57e-11ea-8f0e-962768ff328a.gif)

